### PR TITLE
fix: rails 5.1 csrf hook

### DIFF
--- a/lib/oxymoron/engine.rb
+++ b/lib/oxymoron/engine.rb
@@ -25,7 +25,8 @@ module Oxymoron
     end
 
     initializer 'oxymoron.csrf' do |app|
-      ActiveSupport.on_load(:action_controller) do
+      component_name = "action_controller#{Rails.version =~ /^5.[^0]/ ? '_base' : ''}"
+      ActiveSupport.on_load(component_name) do
         include ::Oxymoron::Concern
       end
     end


### PR DESCRIPTION
Это нужно, чтобы в рельсе 5.1 не падал ActionController::API.
В рельсе 5.0 и ниже использовать ActionController::API c оксюмороном нельзя